### PR TITLE
Use Double Quotes in Dockerfile RUN block

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN wget https://github.com/OpenMage/magento-mirror/archive/${MAGENTO_VERSION}.t
 
 # Apply config & patches
 COPY . /
-RUN sed -i '/root/a include magento_*.conf;' /templates/nginx-default.conf.j2 && \
-    sed -i "s/isset(\$_SERVER\['MAGE_IS_DEVELOPER_MODE'\])/getenv('APPLICATION_ENV') == 'dev'/" index.php && \
-    sed -i "/setIsDeveloperMode(true);/a ini_set('display_errors', 1);" index.php && \
+RUN sed -i "/root/a include magento_*.conf;" /templates/nginx-default.conf.j2 && \
+    sed -i "s/isset(\$_SERVER\[\"MAGE_IS_DEVELOPER_MODE\"\])/getenv(\"APPLICATION_ENV\") == \"dev\"/" index.php && \
+    sed -i "/setIsDeveloperMode(true);/a ini_set(\"display_errors\", 1);" index.php && \
     patch -p0 < /uploader.patch
 
 # Persist certain folders


### PR DESCRIPTION
Avoid this linter warning: `Arguments to RUN in exec for must not contain single quotes`
